### PR TITLE
Updates rxjs to version 6.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { Observable } = require( 'rxjs' );
+const {of} = require('rxjs');
 
 
 /**
@@ -13,5 +13,5 @@ const { Observable } = require( 'rxjs' );
  *
  */
 module.exports.init = ( name = 'Unknow user' ) =>
-    Observable.of( `${name}, Welcome to msg labs!` );
+    of( `${name}, Welcome to msg labs!` );
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const {of} = require('rxjs');
+const { of } = require( 'rxjs' );
 
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1474,11 +1474,11 @@
       }
     },
     "rxjs": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.0.0.tgz",
+      "integrity": "sha512-2MgLQr1zvks8+Kip4T6hcJdiBhV+SIvxguoWjhwtSpNPTp/5e09HJbgclCwR/nW0yWzhubM+6Q0prl8G5RuoBA==",
       "requires": {
-        "symbol-observable": "1.0.1"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -1681,11 +1681,6 @@
         "has-flag": "^3.0.0"
       }
     },
-    "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
-    },
     "text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -1718,6 +1713,11 @@
       "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
+    },
+    "tslib": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/msg-labs/test-module"
   },
   "dependencies": {
-    "rxjs": "^5.4.0"
+    "rxjs": "^6.0.0"
   },
   "devDependencies": {
     "standard-version": "7.0.1"


### PR DESCRIPTION
A review of the code indicates that no other parts are affected by the breaking changes in the library update.